### PR TITLE
Add 1.8.0.9 old jar file and README explaining the folder and why it's here

### DIFF
--- a/old_jars/README.md
+++ b/old_jars/README.md
@@ -1,0 +1,4 @@
+These 'old jar' files are downloaded and packaged with the client game engine.
+They are packaged here to avoid adding binary files to our main code repository.
+The files are used to launch 'old' binaries of the game to play save games taken from
+and older version.


### PR DESCRIPTION
- The build already clones the assets directory, so we just need to update the game engine build to move and rename 'old_jars' to 'old'