### PR TITLE
Add travis build to compress and zip images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ install: skip
 script:
   - ./.travis/run_optipng
   - ./.travis/zip_assets
+  - ./.travis/push_tag
 deploy:
   provider: releases
   api_key: "$BOT_AUTH_TOKEN"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+dist: xenial
+if: tag is blank
+install: skip
+script:
+  - ./.travis/run_optipng
+  - ./.travis/zip_assets
+deploy:
+  provider: releases
+  api_key: "$BOT_AUTH_TOKEN"
+  file_glob: true
+  file: artifacts/*
+  skip_cleanup: true
+  name: $TRAVIS_BUILD_NUMBER
+  on: {tags: false, branch: master}
+

--- a/.travis/push_tag
+++ b/.travis/push_tag
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+## Releases will be created under the latest tag pushed, or Travis
+## will create a name for the tag automatically if there is none.
+## The tag name is part of the download URL, naming and pushing a 
+## tag keeps the download URL predictable and easier to update.
+
+readonly REPO_URL="https://${BOT_AUTH_TOKEN}@github.com/triplea-game/assets.git"
+git config --global user.email "tripleabuilderbot@gmail.com"
+git config --global user.name "tripleabuilderbot"
+
+git tag "$TRAVIS_BUILD_NUMBER" -a -f -m "$TAG_VALUE"
+git push -q "$REPO_URL" --tags
+

--- a/.travis/run_optipng
+++ b/.travis/run_optipng
@@ -8,7 +8,6 @@ git config --global user.email "tripleabuilderbot@gmail.com"
 git config --global user.name "tripleabuilderbot"
 
 
-
 ## find all PNG files, run lossless compression
 ## Filter output for errors, the line stating which file is being proccessed and percentage decrease
 find . -name "*png" \
@@ -24,8 +23,7 @@ set -e
 ## If we trigger a new build, terminate the current build so we avoid deploying artifacts
 git commit . -m "Apply optipng compression on all png files" && \
 (
-  git remote add repo "$REPO_URL" &> /dev/null
-  git push --quiet --set-upstream repo master
+  git push --quiet "$REPO_URL" master
   echo "Committed compressed files. Terminating current build to abort deployment"
   exit 1
 )

--- a/.travis/run_optipng
+++ b/.travis/run_optipng
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+readonly REPO_URL="https://${BOT_AUTH_TOKEN}@github.com/triplea-game/assets.git"
+sudo apt install optipng
+
+git checkout  master
+git config --global user.email "tripleabuilderbot@gmail.com"
+git config --global user.name "tripleabuilderbot"
+
+
+
+## find all PNG files, run lossless compression
+## Filter output for errors, the line stating which file is being proccessed and percentage decrease
+find . -name "*png" \
+  | xargs optipng -preserve -o7 2>&1 \
+  | grep -iE "^** Processing|% decrease|error|warn"
+
+## Toggle flag to fail on non-zero exit code.
+## This will cause Travis to discontinue the build if we terminate with non-zero.
+set -e
+
+## If any files are changed, we'll commit them here
+## If we commit and push, that will trigger a new build.
+## If we trigger a new build, terminate the current build so we avoid deploying artifacts
+git commit . -m "Apply optipng compression on all png files" && \
+(
+  git remote add repo "$REPO_URL" &> /dev/null
+  git push --quiet --set-upstream repo master
+  echo "Committed compressed files. Terminating current build to abort deployment"
+  exit 1
+)
+
+exit 0

--- a/.travis/zip_assets
+++ b/.travis/zip_assets
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+(cd game_headed_assets || exit 1; zip -r game_headed_assets.zip -- *)
+
+mkdir -p artifacts/
+mv game_headed_assets/game_headed_assets.zip ./artifacts/


### PR DESCRIPTION
(1) Adds a travis build script to deploy zip files
(2) Adds a script to run 'optipng', lossless png compression
  - If any files are compressed, we'll use the bot account to commit them.
    If any files are committed, we'll push and abort the current build.
    The newly pushed commit will trigger a new build.
(3) Adds a script to zip up the game_headed_assets and posts the zip file
    to github releases.

--------------

- Tested the scripts on a demo repo, see: https://github.com/DanVanAtta/test/releases/latest
- Env variable: BOT_AUTH_TOKEN has been added to [travis build setttings](https://travis-ci.org/triplea-game/assets/settings). The build script should be good to go post-merge.
- Ignore the build failure. PR builds are now turned off, tested with: https://github.com/triplea-game/assets/pull/38