### PR TITLE
Bugfix, fix find *png picking up 'run_optipng' script

### DIFF
--- a/.travis/run_optipng
+++ b/.travis/run_optipng
@@ -10,7 +10,7 @@ git config --global user.name "tripleabuilderbot"
 
 ## find all PNG files, run lossless compression
 ## Filter output for errors, the line stating which file is being proccessed and percentage decrease
-find . -name "*png" \
+find . -name "*.png" \
   | xargs optipng -preserve -o7 2>&1 \
   | grep -iE "^** Processing|% decrease|error|warn"
 


### PR DESCRIPTION
Build failed because optipng tried to run against the script 'run_optipng'. This is because the file glob was looking for files ending in "png" rather than files ending with ".png"