### PR TITLE
Bump tag value, add a prefixed '1' to avoid collissions with upcoming  build numbers

### DIFF
--- a/.travis/push_tag
+++ b/.travis/push_tag
@@ -9,6 +9,9 @@ readonly REPO_URL="https://${BOT_AUTH_TOKEN}@github.com/triplea-game/assets.git"
 git config --global user.email "tripleabuilderbot@gmail.com"
 git config --global user.name "tripleabuilderbot"
 
-git tag "$TRAVIS_BUILD_NUMBER" -a -f -m "$TAG_VALUE"
+## Add a '1' prefix to the build number to avoid
+## collisions. A travis migration to travic-ci.com
+## reset the build numbers.
+git tag "1$TRAVIS_BUILD_NUMBER" -a -f -m "$TAG_VALUE"
 git push -q "$REPO_URL" --tags
 


### PR DESCRIPTION
Migrating from travis-ci.org to travis-ci.com seemingly reset build numbers
The previous latest tag was 25, the current build is on 15. To avoid collissions,
jump to tag 116 for the next build.